### PR TITLE
Add jars needed to access AWS S3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,9 @@ ADD http://central.maven.org/maven2/com/google/guava/guava/23.0/guava-23.0.jar $
 # Add the connector jar needed to access Google Cloud Storage using the Hadoop FileSystem API.
 ADD https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-latest-hadoop2.jar $SPARK_HOME/jars
 
+# Add dependency for hadoop-aws
+ADD http://central.maven.org/maven2/com/amazonaws/aws-java-sdk/1.7.4/aws-java-sdk-1.7.4.jar $SPARK_HOME/jars
+# Add hadoop-aws to access Amazon S3
+ADD http://central.maven.org/maven2/org/apache/hadoop/hadoop-aws/2.7.5/hadoop-aws-2.7.5.jar $SPARK_HOME/jars
+
 ENTRYPOINT ["/opt/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,5 @@ The [Cloud Storage connector](https://cloud.google.com/dataproc/docs/concepts/co
 
 ### S3
 
-To-do
-
+The [hadoop-aws](https://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/index.html) is included in the image to support AWS S3 integration
  


### PR DESCRIPTION
# Summary
As a part of contribution to the spark-history-server helm chart, I added [hadoop-aws](https://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/index.html) jar and its dependency to support AWS S3 integration.

@yuchaoran2011 Could you please take a look?